### PR TITLE
Add two citation files 

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Wallace
+    given-names: Edward
+  - family-names: Haynes
+    given-names: Sam
+title: "The tidyqpcr R Package: Quantitative PCR analysis in the tidyverse." 
+version: 0.3.0
+date-released: 2021-10-07
+license: Apache-2.0
+repository-code: "https://github.com/ewallace/tidyqpcr"

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,11 @@
+citHeader("To cite tidyqpcr in publications use:")
+
+citEntry(
+  entry    = "misc",
+  title    = "The tidyqpcr R Package: Quantitative PCR analysis in the tidyverse.",
+  author   = c(person("Edward Wallace"), person("Sam Haynes")),
+  year     = "2021",
+  url      = "https://github.com/ewallace/tidyqpcr",
+  textVersion = paste(
+ "Haynes, S., Wallace, E.W.J. (2021). The tidyqpcr R Package: Quantitative PCR analysis in the tidyverse (Version 0.3) [Software]. Available from https://github.com/ewallace/tidyqpcr.")
+  )


### PR DESCRIPTION
R requires a CITATION file in the inst folder to create the software citation using the citation function. However, GitHub needs a CITATION.cff in the root repo to create a software citation.